### PR TITLE
Add support for `--indulgent-ordering` option

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,3 +2,4 @@ Frank Tobia <frank.tobia@gmail.com>
 Sergei Chipiga <svchipiga@yandex-team.ru>
 Ben Greene <B.Greene@analyticsengines.com>
 Adam Talsma <adam@talsma.ca>
+Andrew Gilbert <andrewg800@gmail.com>

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 Unreleased
 ---
 ### Added
-- #?? Add ``--indulgent-ordering`` to request that the sort from
+- #50 Add ``--indulgent-ordering`` to request that the sort from
   pytest-ordering be run before other plugins.  This allows the built-in
   ``--failed-first`` implementation to override the ordering.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+Unreleased
+---
+### Added
+- #?? Add ``--indulgent-ordering`` to request that the sort from
+  pytest-ordering be run before other plugins.  This allows the built-in
+  ``--failed-first`` implementation to override the ordering.
 
 0.6
 ---

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -114,6 +114,21 @@ You can also use markers such as "first", "second", "last", and "second_to_last"
 
     =========================== 4 passed in 0.02 seconds ===========================
 
+``--indulgent-ordering`` and overriding ordering
+-------------
+
+You may sometimes find that you want to suggest an ordering of tests, while
+allowing it to be overridden for good reson. For example, if you run your test
+suite in parallel and have a number of tests which are particularly slow, it
+might be desirable to start those tests running first, in order to optimize
+your completion time. You can use the pytest-ordering plugin to inform pytest
+of this. Now suppose you also want to prioritize tests which failed during the
+previous run, by using the ``--failed-first`` option. By default,
+pytest-ordering will override the ``--failed-first`` order, but by adding the
+``--indulgent-ordering`` option, you can ask pytest to run the sort from
+pytest-ordering *before* the sort from ``--failed-first``, allowing the failed
+tests to be sorted to the front.
+
 
 Aspirational
 ============

--- a/pytest_ordering/__init__.py
+++ b/pytest_ordering/__init__.py
@@ -60,7 +60,7 @@ def pytest_addoption(parser):
 order provided by pytest-ordering be applied before other sorting, allowing the \
 other sorting to have priority''')
 
-class OrderingPlugin:
+class OrderingPlugin(object):
     """
     Plugin implementation
 

--- a/pytest_ordering/__init__.py
+++ b/pytest_ordering/__init__.py
@@ -26,7 +26,7 @@ orders_map = {
 
 
 def pytest_configure(config):
-    """Register the "run" marker and configur the plugin depending on the CLI
+    """Register the "run" marker and configure the plugin depending on the CLI
     options"""
 
     config_line = (

--- a/tests/test_indulgent_ordering.py
+++ b/tests/test_indulgent_ordering.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+import re
+
+import pytest
+import pytest_ordering
+
+pytest_plugins = ["pytester"]
+
+
+def test_run_marker_registered(capsys, tmpdir):
+    testname = str(tmpdir.join("failing.py"))
+    with open(testname, "w") as fi:
+        fi.write(
+            """
+import pytest
+
+@pytest.mark.first
+def test_me_first():
+    assert True
+
+@pytest.mark.second
+def test_me_second():
+    assert True
+
+def test_that_fails():
+    assert False
+"""
+        )
+    args = ["--quiet", "--color=no", testname]
+    pytest.main(args, [pytest_ordering])
+    out, err = capsys.readouterr()
+    assert "..F" in out
+    args.insert(0, "--ff")
+    pytest.main(args, [pytest_ordering])
+    out, err = capsys.readouterr()
+    assert "..F" in out
+    args.insert(0, "--indulgent-ordering")
+    pytest.main(args, [pytest_ordering])
+    out, err = capsys.readouterr()
+    assert "F.." in out

--- a/tests/test_indulgent_ordering.py
+++ b/tests/test_indulgent_ordering.py
@@ -14,16 +14,16 @@ def test_run_marker_registered(capsys, tmpdir):
             """
 import pytest
 
-@pytest.mark.first
-def test_me_first():
-    assert True
-
 @pytest.mark.second
 def test_me_second():
     assert True
 
 def test_that_fails():
     assert False
+
+@pytest.mark.first
+def test_me_first():
+    assert True
 """
         )
     args = ["--quiet", "--color=no", testname]

--- a/tests/test_ordering.py
+++ b/tests/test_ordering.py
@@ -269,6 +269,6 @@ def test_order_mark_class(item_names_for):
 
 
 def test_run_marker_registered(capsys):
-    pytest.main('--markers')
+    pytest.main(['--markers'])
     out, err = capsys.readouterr()
     assert '@pytest.mark.run' in out


### PR DESCRIPTION
This requests that the plugin be run first, allowing other plugins to
override its ordering. This is useful if the order requirements
provided by this plugin are intended to be priorities, rather than
absolute requirements. For example, if some test cases run slower than
others in your test suite, you can mark them as desirable to run first
when running tests in parallel, allowing a more efficient use of a
multi-core processor. By adding the `--indulgent-ordering` option,
this ordering can still be overridden by, for example, the
`--failed-first` option, which prioritizes tests which failed during
the last run. Without `--indulgent-ordering`, the `--failed-first`
option will be overridden by pytest-ordering, reducing its usefulness
by increasing the total time until the results are available.