### PR TITLE
Fix CI build

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,3 +2,4 @@ Frank Tobia <frank.tobia@gmail.com>
 Sergei Chipiga <svchipiga@yandex-team.ru>
 Ben Greene <B.Greene@analyticsengines.com>
 Adam Talsma <adam@talsma.ca>
+Andrew Gilbert <andrewg800@gmail.com>

--- a/tests/test_ordering.py
+++ b/tests/test_ordering.py
@@ -269,6 +269,6 @@ def test_order_mark_class(item_names_for):
 
 
 def test_run_marker_registered(capsys):
-    pytest.main('--markers')
+    pytest.main(['--markers'])
     out, err = capsys.readouterr()
     assert '@pytest.mark.run' in out


### PR DESCRIPTION
For some reason, it seems the CI build on dev had broken, due to `pytest.main` not being passed a list of arguments as it expected. This pull converts the single string argument to a list.