### PR TITLE
Add xdist test

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,3 +2,4 @@ Frank Tobia <frank.tobia@gmail.com>
 Sergei Chipiga <svchipiga@yandex-team.ru>
 Ben Greene <B.Greene@analyticsengines.com>
 Adam Talsma <adam@talsma.ca>
+Andrew Gilbert <andrewg800@gmail.com>

--- a/tests/test_ordering.py
+++ b/tests/test_ordering.py
@@ -269,6 +269,6 @@ def test_order_mark_class(item_names_for):
 
 
 def test_run_marker_registered(capsys):
-    pytest.main('--markers')
+    pytest.main(['--markers'])
     out, err = capsys.readouterr()
     assert '@pytest.mark.run' in out

--- a/tests/test_xdist_handling.py
+++ b/tests/test_xdist_handling.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+import pytest_ordering
+
+pytest_plugins = ['pytester']
+
+
+def test_xdist_ordering(tmpdir):
+    testname = str(tmpdir.join("first_test.py"))
+    with open(testname, "w") as fi:
+        fi.write(
+            """
+import pytest
+
+val = 1
+
+@pytest.mark.second
+def test_second_integer():
+    global val
+    assert val == 2
+    val += 1
+
+def test_last_integer():
+    assert val == 3
+
+@pytest.mark.first
+def test_first_integer():
+    global val
+    assert val == 1
+    val += 1
+"""
+        )
+
+    testname = str(tmpdir.join("second_test.py"))
+    with open(testname, "w") as fi:
+        fi.write(
+            """
+import pytest
+
+val = "frog"
+
+@pytest.mark.second
+def test_second_string():
+    global val
+    assert val == "goat"
+    val = "fish"
+
+def test_last_string():
+    assert val == "fish"
+
+@pytest.mark.first
+def test_first_string():
+    global val
+    assert val == "frog"
+    val = "goat"
+"""
+        )
+    # With `loadfile`, the tests should pass
+    args = ["-n3", "--dist=loadfile", str(tmpdir)]
+    ret = pytest.main(args, [pytest_ordering])
+    assert ret == 0
+
+    # Without `loadfile`, the tests should fail
+    args = ["-n3", str(tmpdir)]
+    ret = pytest.main(args, [pytest_ordering])
+    assert ret == 1

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = py26,py27,py33,py34,py35,pypy
 [testenv]
 deps=pytest
     pytest-cov
+    pytest-xdist
 commands=
     coverage run --source=pytest_ordering -m py.test tests
     coverage report -m --fail-under=95


### PR DESCRIPTION
Create a test to check that a version of #36 can be achieved as-is.

By  telling xdist to keep tests from one file together on one thread using `--dist=loadfile`, we can make sure that dependent tests are executed on the same thread, as long as they're in the same file.