### PR TITLE
Add relative to other tests 'run' mark 'after' and 'before' kwargs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -121,6 +121,47 @@ You can also use markers such as "first", "second", "last", and "second_to_last"
     =========================== 4 passed in 0.02 seconds ===========================
 
 
+Relative to other tests
+-----------------------
+
+Tests can be defined relative to others with "before" and "after" parameters.
+
+.. code:: python
+
+ import pytest
+
+ @pytest.mark.run(after='test_second')
+ def test_third():
+     assert True
+
+ def test_second():
+     assert True
+
+ @pytest.mark.run(before='test_second')
+     def test_first():
+         assert True
+
+::
+
+    $ py.test test_foo.py -vv
+    ============================= test session starts ==============================
+    platform darwin -- Python 2.7.5 -- py-1.4.20 -- pytest-2.5.2 -- env/bin/python
+    plugins: ordering
+    collected 3 items
+
+    test_foo.py:11: test_first PASSED
+    test_foo.py:7: test_second PASSED
+    test_foo.py:4: test_third PASSED
+
+    =========================== 4 passed in 0.02 seconds ===========================
+
+
+
+    .. toctree::
+       :maxdepth: 2
+
+    .. _markers: https://pytest.org/latest/mark.html
+
 Aspirational
 ============
 
@@ -203,45 +244,4 @@ By number
     test_foo.py:7: test_four PASSED
 
     =========================== 4 passed in 0.02 seconds ===========================
-
-
-Relative to other tests
------------------------
-
-
-.. code:: python
-
- import pytest
-
- @pytest.mark.run(after='test_second')
- def test_third():
-     assert True
-
- def test_second():
-     assert True
-
- @pytest.mark.run(before='test_second')
- def test_first():
-     assert True
-
-::
-
-    $ py.test test_foo.py -vv
-    ============================= test session starts ==============================
-    platform darwin -- Python 2.7.5 -- py-1.4.20 -- pytest-2.5.2 -- env/bin/python
-    plugins: ordering
-    collected 3 items
-
-    test_foo.py:11: test_first PASSED
-    test_foo.py:7: test_second PASSED
-    test_foo.py:4: test_third PASSED
-
-    =========================== 4 passed in 0.02 seconds ===========================
-
-
-
-.. toctree::
-   :maxdepth: 2
-
-.. _markers: https://pytest.org/latest/mark.html
 

--- a/pytest_ordering/__init__.py
+++ b/pytest_ordering/__init__.py
@@ -108,12 +108,12 @@ def pytest_collection_modifyitems(session, config, items):
         else:
             if len(_before_items) == 1:
                 message_schema = "%s, indicated at parameter before of" \
-                               + " %s, doesn't exists"
+                               + " %s, doesn't exist"
                 message = message_schema % (before_item_relative,
                                             _before_items[0].name)
             else:
                 message_schema = "%s, indicated at parameter before of" \
-                               + " %s, doesn't exists"
+                               + " %s, doesn't exist"
                 test_names = ""
                 for i, before_item in enumerate(_before_items):
                     test_names += before_item.name
@@ -132,12 +132,12 @@ def pytest_collection_modifyitems(session, config, items):
         else:
             if len(_after_items) == 1:
                 message_schema = "%s, indicated at parameter after of" \
-                               + " %s, doesn't exists"
+                               + " %s, doesn't exist"
                 message = message_schema % (after_item_relative,
                                             _after_items[0].name)
             else:
                 message_schema = "%s, indicated at parameter after of" \
-                               + " %s, doesn't exists"
+                               + " %s, doesn't exist"
                 test_names = ""
                 for i, after_item in enumerate(_after_items):
                     test_names += after_item.name

--- a/pytest_ordering/__init__.py
+++ b/pytest_ordering/__init__.py
@@ -107,13 +107,13 @@ def pytest_collection_modifyitems(session, config, items):
                 items.insert(index, before_item)
         else:
             if len(_before_items) == 1:
-                message_schema = "%s test, indicated at parameter before of" \
-                               + " %s test, doesn't exists"
+                message_schema = "%s, indicated at parameter before of" \
+                               + " %s, doesn't exists"
                 message = message_schema % (before_item_relative,
                                             _before_items[0].name)
             else:
-                message_schema = "%s test, indicated at parameter before of" \
-                               + " %s tests, doesn't exists"
+                message_schema = "%s, indicated at parameter before of" \
+                               + " %s, doesn't exists"
                 test_names = ""
                 for i, before_item in enumerate(_before_items):
                     test_names += before_item.name
@@ -131,13 +131,13 @@ def pytest_collection_modifyitems(session, config, items):
                 items.insert(index+1, after_item)
         else:
             if len(_after_items) == 1:
-                message_schema = "%s test, indicated at parameter after of" \
-                               + " %s test, doesn't exists"
+                message_schema = "%s, indicated at parameter after of" \
+                               + " %s, doesn't exists"
                 message = message_schema % (after_item_relative,
                                             _after_items[0].name)
             else:
-                message_schema = "%s test, indicated at parameter after of" \
-                               + " %s tests, doesn't exists"
+                message_schema = "%s, indicated at parameter after of" \
+                               + " %s, doesn't exists"
                 test_names = ""
                 for i, after_item in enumerate(_after_items):
                     test_names += after_item.name

--- a/pytest_ordering/__init__.py
+++ b/pytest_ordering/__init__.py
@@ -48,6 +48,7 @@ def pytest_configure(config):
 
 def pytest_collection_modifyitems(session, config, items):
     grouped_items = {}
+    before_items, after_items = ({}, {})
 
     for item in items:
 
@@ -62,6 +63,20 @@ def pytest_collection_modifyitems(session, config, items):
 
         if mark:
             order = mark.kwargs.get('order')
+            if order is None:
+                before = mark.kwargs.get('before')
+                if before:
+                    if not before in before_items:
+                        before_items[before] = []
+                    before_items[before].append(item)
+                    continue
+                
+                after = mark.kwargs.get('after')
+                if after:
+                    if not after in after_items:
+                        after_items[after] = []
+                    after_items[after].append(item)
+                    continue
         else:
             order = None
 
@@ -80,3 +95,22 @@ def pytest_collection_modifyitems(session, config, items):
     sorted_items.extend([i[1] for i in end_list])
 
     items[:] = [item for sublist in sorted_items for item in sublist]
+    
+    def _get_item_index_by_name(item_name):
+        index = None
+        for i, item in enumerate(items):
+            if getattr(item, "name") == item_name:
+                index = i
+                break
+        return index
+        
+    for before_item_relative, _before_items in before_items.items():
+        index = _get_item_index_by_name(before_item_relative)
+        if index is not None:
+            for before_item in _before_items:
+                items.insert(index, before_item)
+    for after_item_relative, _after_items in after_items.items():
+        index = _get_item_index_by_name(after_item_relative)
+        if index is not None:
+            for after_item in _after_items:
+                items.insert(index+1, after_item)

--- a/tests/test_ordering.py
+++ b/tests/test_ordering.py
@@ -318,10 +318,10 @@ def test_relative_to_other_invalid_tests(item_names_for):
         ]
         
         expected_warning_messages = [
-            "test_A test, indicated at parameter before of test_1 test, doesn't exists",
-            "test_B test, indicated at parameter after of test_3 test, doesn't exists",
-            "test_C test, indicated at parameter before of test_4, test_5 and test_6 tests, doesn't exists",
-            "test_D test, indicated at parameter after of test_7 and test_8 tests, doesn't exists",
+            "test_A, indicated at parameter before of test_1, doesn't exists",
+            "test_B, indicated at parameter after of test_3, doesn't exists",
+            "test_C, indicated at parameter before of test_4, test_5 and test_6, doesn't exists",
+            "test_D, indicated at parameter after of test_7 and test_8, doesn't exists",
         ]
         
         n_other_warnings = 0        

--- a/tests/test_ordering.py
+++ b/tests/test_ordering.py
@@ -312,10 +312,12 @@ def test_relative_to_other_invalid_tests(item_names_for):
     """
     
     with warnings.catch_warnings(record=True) as catched_warnings:
-        assert item_names_for(tests_content) == [
+        expected_item_names = [
             'test_2', 'test_1', 'test_4', 'test_5',
             'test_6', 'test_3', 'test_7', 'test_8',
         ]
+        for item_name in item_names_for(tests_content):
+            assert item_name in expected_item_names
         
         expected_warning_messages = [
             "test_A, indicated at parameter before of test_1, doesn't exist",

--- a/tests/test_ordering.py
+++ b/tests/test_ordering.py
@@ -268,6 +268,21 @@ def test_order_mark_class(item_names_for):
     assert item_names_for(tests_content) == ['test_3', 'test_4', 'test_5', 'test_1', 'test_2']
 
 
+def test_relative_to_other_tests(item_names_for):
+    tests_content = """
+    import pytest
+    
+    @pytest.mark.run(after='test_2')
+    def test_3(): pass
+
+    def test_2(): pass
+
+    @pytest.mark.run(before='test_2')
+    def test_1(): pass
+    """
+    assert item_names_for(tests_content) == ['test_1', 'test_2', 'test_3']
+
+
 def test_markers_registered(capsys):
     pytest.main(['--markers'])
     out, err = capsys.readouterr()

--- a/tests/test_ordering.py
+++ b/tests/test_ordering.py
@@ -318,10 +318,10 @@ def test_relative_to_other_invalid_tests(item_names_for):
         ]
         
         expected_warning_messages = [
-            "test_A, indicated at parameter before of test_1, doesn't exists",
-            "test_B, indicated at parameter after of test_3, doesn't exists",
-            "test_C, indicated at parameter before of test_4, test_5 and test_6, doesn't exists",
-            "test_D, indicated at parameter after of test_7 and test_8, doesn't exists",
+            "test_A, indicated at parameter before of test_1, doesn't exist",
+            "test_B, indicated at parameter after of test_3, doesn't exist",
+            "test_C, indicated at parameter before of test_4, test_5 and test_6, doesn't exist",
+            "test_D, indicated at parameter after of test_7 and test_8, doesn't exist",
         ]
         
         n_other_warnings = 0        


### PR DESCRIPTION
Closes #65 

As was reported, [relative to other tests module ordering](https://pytest-ordering.readthedocs.io/en/develop/#relative-to-other-tests) is not working because is not implemented.