### PR TITLE
Include LICENSE file in distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
Closes #63

You can check it running `python setup.py sdist` and extracting the `.tar` to see the file `LICENSE` included.