### PR TITLE
Fixed Travis.CI builds, added more versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ dist: xenial
 language: python
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
   - "pypy"
 install:
   - pip install tox

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -57,11 +57,11 @@ With pytest-ordering, you can change the default ordering as follows:
 
  import pytest
 
- @pytest.mark.order2
+ @pytest.mark.run(order=1)
  def test_foo():
      assert True
 
- @pytest.mark.order1
+ @pytest.mark.run(order=0)
  def test_bar():
      assert True
 
@@ -79,6 +79,37 @@ With pytest-ordering, you can change the default ordering as follows:
     =========================== 2 passed in 0.01 seconds ===========================
 
 This is a trivial example, but ordering is respected across test files.
+
+Negative ordinals
+-----------------
+
+Just like a list index in Python, negative ordinals count from the end, e.g.
+the ordinal -1 designates the last test, -2 the second to last etc.:
+
+.. code:: python
+
+ import pytest
+
+ @pytest.mark.run(order=-2)
+ def test_foo():
+     assert True
+
+ @pytest.mark.run(order=-1)
+ def test_bar():
+     assert True
+
+::
+
+    $ py.test test_foo.py -vv
+    ============================= test session starts ==============================
+    platform darwin -- Python 2.7.5 -- py-1.4.20 -- pytest-2.5.2 -- env/bin/python
+    plugins: ordering
+    collected 2 items
+
+    test_foo.py:7: test_bar PASSED
+    test_foo.py:3: test_foo PASSED
+
+    =========================== 2 passed in 0.01 seconds ===========================
 
 Other markers
 -------------
@@ -120,6 +151,77 @@ You can also use markers such as "first", "second", "last", and "second_to_last"
 
     =========================== 4 passed in 0.02 seconds ===========================
 
+Sparse ordinals
+---------------
+Both when using ordinal numbers and when using keywords as shown above, you
+can leave out some of the numbers. If there are unmarked tests, they will
+fill in the gaps. Consider this (note that the ordinals are 0-based):
+
+.. code:: python
+
+    import pytest
+
+    @pytest.mark.run(order=2)
+    def test_1():
+        assert True
+
+    def test_2():
+        assert True
+
+    def test_3():
+        assert True
+
+    @pytest.mark.run(order=0)
+    def test_4():
+        assert True
+
+::
+
+    $ py.test test_foo.py -vv
+    ================================================= test session starts =================================================
+    platform win32 -- Python 3.7.1, pytest-5.4.3, py-1.8.1, pluggy-0.13.1 -- c:\dev\venv\py37_test\scripts\python.exe
+    collected 4 items
+
+    test_ordering.py::test_4 PASSED                                                                                  [ 25%]
+    test_ordering.py::test_2 PASSED                                                                                  [ 50%]
+    test_ordering.py::test_1 PASSED                                                                                  [ 75%]
+    test_ordering.py::test_3 PASSED                                                                                  [100%]
+
+    ================================================== 4 passed in 0.08s ==================================================
+
+This also works for negative numbers:
+
+.. code:: python
+
+    import pytest
+
+    @pytest.mark.run(order=-3)
+    def test_1():
+        assert True
+
+    def test_2():
+        assert True
+
+    def test_3():
+        assert True
+
+    @pytest.mark.run(order=-1)
+    def test_4():
+        assert True
+
+::
+
+    $ py.test test_foo.py -vv
+    ================================================= test session starts =================================================
+    platform win32 -- Python 3.7.1, pytest-5.4.3, py-1.8.1, pluggy-0.13.1 -- c:\dev\venv\py37_test\scripts\python.exe
+    collected 4 items
+
+    test_ordering.py::test_2 PASSED                                                                                  [ 25%]
+    test_ordering.py::test_1 PASSED                                                                                  [ 50%]
+    test_ordering.py::test_3 PASSED                                                                                  [ 75%]
+    test_ordering.py::test_4 PASSED                                                                                  [100%]
+
+    ================================================== 4 passed in 0.07s ==================================================
 
 Aspirational
 ============
@@ -147,45 +249,6 @@ Ordinals
      assert True
 
  @pytest.mark.run('first')
- def test_one():
-     assert True
-
-::
-
-    $ py.test test_foo.py -vv
-    ============================= test session starts ==============================
-    platform darwin -- Python 2.7.5 -- py-1.4.20 -- pytest-2.5.2 -- env/bin/python
-    plugins: ordering
-    collected 4 items
-
-    test_foo.py:17: test_one PASSED
-    test_foo.py:12: test_two PASSED
-    test_foo.py:3: test_three PASSED
-    test_foo.py:7: test_four PASSED
-
-    =========================== 4 passed in 0.02 seconds ===========================
-
-
-By number
----------
-
-.. code:: python
-
- import pytest
-
- @pytest.mark.run(order=-2)
- def test_three():
-     assert True
-
- @pytest.mark.run(order=-1)
- def test_four():
-     assert True
-
- @pytest.mark.run(order=2)
- def test_two():
-     assert True
-
- @pytest.mark.run(order=1)
  def test_one():
      assert True
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+import pytest
+
+
+@pytest.fixture
+def item_names_for(testdir):
+
+    def _item_names_for(tests_content):
+        # some strange code to extract sorted items
+        items = testdir.getitems(tests_content)
+        hook = testdir.config.hook
+        hook.pytest_collection_modifyitems(session=items[0].session,
+                                           config=testdir.config, items=items)
+        return [item.name for item in items]
+
+    return _item_names_for
+

--- a/tests/test_ordering.py
+++ b/tests/test_ordering.py
@@ -1,23 +1,8 @@
 # -*- coding: utf-8 -*-
-import re
 
 import pytest
 
 pytest_plugins = ['pytester']
-
-
-@pytest.fixture
-def item_names_for(testdir):
-
-    def _item_names_for(tests_content):
-        # some strange code to extract sorted items
-        items = testdir.getitems(tests_content)
-        hook = testdir.config.hook
-        hook.pytest_collection_modifyitems(session=items[0].session,
-                                           config=testdir.config, items=items)
-        return [item.name for item in items]
-
-    return _item_names_for
 
 
 def test_no_marks(item_names_for):
@@ -149,7 +134,9 @@ def test_non_contiguous_inc_zero(item_names_for):
     def test_7(): pass
     """
 
-    assert item_names_for(tests_content) == ['test_7', 'test_3', 'test_1', 'test_2', 'test_5', 'test_4', 'test_6']
+    assert item_names_for(tests_content) == ['test_7', 'test_3', 'test_1',
+                                             'test_2', 'test_5', 'test_4',
+                                             'test_6']
 
 
 def test_non_contiguous_inc_none(item_names_for):
@@ -174,7 +161,8 @@ def test_non_contiguous_inc_none(item_names_for):
     def test_6(): pass
     """
 
-    assert item_names_for(tests_content) == ['test_2', 'test_3', 'test_1', 'test_6', 'test_5', 'test_4']
+    assert item_names_for(tests_content) == ['test_2', 'test_3', 'test_6',
+                                             'test_1', 'test_5', 'test_4']
 
 
 def test_first_mark_class(item_names_for):
@@ -238,7 +226,8 @@ def test_first_last_mark_class(item_names_for):
 
     """
 
-    assert item_names_for(tests_content) == ['test_4', 'test_5', 'test_3', 'test_1', 'test_2']
+    assert item_names_for(tests_content) == ['test_4', 'test_5', 'test_3',
+                                             'test_1', 'test_2']
 
 
 def test_order_mark_class(item_names_for):
@@ -265,7 +254,8 @@ def test_order_mark_class(item_names_for):
         def test_5(self): pass
     """
 
-    assert item_names_for(tests_content) == ['test_3', 'test_4', 'test_5', 'test_1', 'test_2']
+    assert item_names_for(tests_content) == ['test_3', 'test_4', 'test_5',
+                                             'test_1', 'test_2']
 
 
 def test_markers_registered(capsys):

--- a/tests/test_ordinals.py
+++ b/tests/test_ordinals.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+
+
+def test_first(item_names_for):
+    tests_content = """
+    import pytest
+
+    def test_1(): pass
+
+    @pytest.mark.first
+    def test_2(): pass
+    """
+    assert item_names_for(tests_content) == ['test_2', 'test_1']
+
+
+def test_second(item_names_for):
+    tests_content = """
+    import pytest
+
+    def test_1(): pass
+    def test_2(): pass
+    def test_3(): pass
+    def test_4(): pass
+
+    @pytest.mark.second
+    def test_5(): pass
+    """
+    assert item_names_for(tests_content) == ['test_1', 'test_5', 'test_2', 'test_3', 'test_4']
+
+
+def test_third(item_names_for):
+    tests_content = """
+    import pytest
+
+    def test_1(): pass
+    def test_2(): pass
+    def test_3(): pass
+
+    @pytest.mark.third
+    def test_4(): pass
+
+    def test_5(): pass
+    """
+    assert item_names_for(tests_content) == ['test_1', 'test_2', 'test_4', 'test_3', 'test_5']
+
+
+def test_second_to_last(item_names_for):
+    tests_content = """
+    import pytest
+
+    def test_1(): pass
+
+    @pytest.mark.second_to_last
+    def test_2(): pass
+
+    def test_3(): pass
+    def test_4(): pass
+    def test_5(): pass
+    """
+    assert item_names_for(tests_content) == ['test_1', 'test_3', 'test_4', 'test_2', 'test_5']
+
+
+def test_last(item_names_for):
+    tests_content = """
+    import pytest
+
+    @pytest.mark.last
+    def test_1(): pass
+
+    def test_2(): pass
+    """
+    assert item_names_for(tests_content) == ['test_2', 'test_1']
+
+
+def test_first_last(item_names_for):
+    tests_content = """
+    import pytest
+
+    @pytest.mark.last
+    def test_1(): pass
+
+    @pytest.mark.first
+    def test_2(): pass
+
+    def test_3(): pass
+    """
+    assert item_names_for(tests_content) == ['test_2', 'test_3', 'test_1']

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,8 @@
 # content of: tox.ini, put in same dir as setup.py
 [tox]
-envlist = {py27,py35,py36,py37,pypy}-pytest{36,37,38,39,310,40,41,42,43,44,45}
+envlist =
+    {py27,py35,py36,py37,py38,pypy}-pytest{36,37,38,39,310,40,41,42,43,44,45,46}
+    {py35,py36,py37,py38}-pytest{50,51,52,53,54}
 [testenv]
 deps =
     pytest36: pytest>=3.6,<3.7
@@ -14,7 +16,15 @@ deps =
     pytest43: pytest>=4.3,<4.4
     pytest44: pytest>=4.4,<4.5
     pytest45: pytest>=4.5,<4.6
-    pytest-cov
+    pytest46: pytest>=4.6,<5.0
+    pytest50: pytest>=5.0,<5.1
+    pytest51: pytest>=5.1,<5.2
+    pytest52: pytest>=5.2,<5.3
+    pytest53: pytest>=5.3,<5.4
+    pytest54: pytest>=5.4,<6.0
+    pytest{40,41,42}: attrs<19.2
+    pytest-cov<2.10
+
 commands =
-    coverage run --source=pytest_ordering -m py.test tests
+    coverage run --source=pytest_ordering -m pytest tests
     coverage report -m --fail-under=95

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # content of: tox.ini, put in same dir as setup.py
 [tox]
-envlist = {py27,py34,py35,py36,py37,pypy}-pytest{36,37,38,39,310,40,41,42,43,44,45}
+envlist = {py27,py35,py36,py37,pypy}-pytest{36,37,38,39,310,40,41,42,43,44,45}
 [testenv]
 deps =
     pytest36: pytest>=3.6,<3.7


### PR DESCRIPTION
- remove Python 3.4 (EOL), add Python 3.8
- add pytest versions up to 5.4 (current)
- use pytest instead of py.test
- use compatible versions of pytest-cov and attrs

Note: this does not fix the problem that the builds are not shown in GitHub.