### PR TITLE
Add more pytest versions, fix pytest-cov compatibility issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ dist: xenial
 language: python
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
   - "pypy"
 install:
   - pip install tox

--- a/setup.py
+++ b/setup.py
@@ -39,10 +39,10 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,8 @@
 # content of: tox.ini, put in same dir as setup.py
 [tox]
-envlist = {py27,py34,py35,py36,py37,pypy}-pytest{36,37,38,39,310,40,41,42,43,44,45}
+envlist =
+    {py27,py35,py36,py37,py38,pypy}-pytest{36,37,38,39,310,40,41,42,43,44,45,46}
+    {py35,py36,py37,py38}-pytest{50,51,52,53,54}
 [testenv]
 deps =
     pytest36: pytest>=3.6,<3.7
@@ -14,7 +16,15 @@ deps =
     pytest43: pytest>=4.3,<4.4
     pytest44: pytest>=4.4,<4.5
     pytest45: pytest>=4.5,<4.6
-    pytest-cov
+    pytest46: pytest>=4.6,<5.0
+    pytest50: pytest>=5.0,<5.1
+    pytest51: pytest>=5.1,<5.2
+    pytest52: pytest>=5.2,<5.3
+    pytest53: pytest>=5.3,<5.4
+    pytest54: pytest>=5.4,<6.0
+    pytest{40,41,42}: attrs<19.2
+    pytest-cov<2.10
+
 commands =
-    coverage run --source=pytest_ordering -m py.test tests
+    coverage run --source=pytest_ordering -m pytest tests
     coverage report -m --fail-under=95


### PR DESCRIPTION
- add pytest versions up to 5.4
- remove Python 3.4, add Python 3.8
- use pytest instead of py.test
- use compatible versions of pytest-cov and attrs
- fixes Travis.CI builds